### PR TITLE
Fix the visibility of Eldin field bugs

### DIFF
--- a/locations/overworld.json
+++ b/locations/overworld.json
@@ -599,18 +599,21 @@
           },
           {
             "name": "Eldin Field Bugs",
-            "visibility_rules": [
-              "op_bug"
-            ],
             "sections": [
               {
                 "name": "Grasshopper Male",
+                "visibility_rules": [
+                  "op_bug"
+                ],
                 "item_count": 1,
                 "chest_unopened_img": "images/bug.png",
                 "chest_opened_img": "images/bug_gray.png"
               },
               {
                 "name": "Grasshopper Female",
+                "visibility_rules": [
+                  "op_bug"
+                ],
                 "item_count": 1,
                 "chest_unopened_img": "images/bug.png",
                 "chest_opened_img": "images/bug_gray.png"


### PR DESCRIPTION
This PR fixes the visibility of Eldin field bugs on the map. Before this PR, two grasshoppers in Eldin field were always visible on the map regardless of the Bug Shuffle setting. This is because the `visibility_rules` property was set on the location, which doesn't work. The `visibility_rules` property needs to be set on each section within the location. This PR fixes that.